### PR TITLE
Document installation

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,13 +33,13 @@ jobs:
     metadata:
       branch: master
       targets:
-        - fedora-stable
+        - fedora-all
       list_on_homepage: True
       preserve_project: True
   - job: copr_build
     trigger: release
     metadata:
       targets:
-        - fedora-stable
+        - fedora-all
       list_on_homepage: True
       preserve_project: True

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Requre \[rekure\]
 
-Is Library for storing output of various function and methods to
+Is a library for storing output of various function and methods to
 persistent storage and be able to replay the stored output to functions
 back
 
@@ -15,3 +15,32 @@ back
 - Used for testing [packit-service](https://github.com/packit-service) organization projects
   - ogr
   - packit
+
+## Installation
+
+On Fedora:
+
+```
+$ dnf install python3-requre
+```
+
+Or from PyPI:
+
+```
+$ pip3 install --user requre
+```
+
+You can also install `requre` from `master` branch, if you are brave enough:
+
+You can use our [`packit/packit-requre-master` Copr repository](https://copr.fedorainfracloud.org/coprs/packit/packit-requre-master/):
+
+```
+$ dnf copr enable packit/packit-requre-master
+$ dnf install python3-requre
+```
+
+Or
+
+```
+$ pip3 install --user git+https://github.com/packit/requre.git
+```


### PR DESCRIPTION
- Document installation instructions in README.
- Enable all fedora targets for master/release copr builds.