### PR TITLE
optimise files handling

### DIFF
--- a/requre/postprocessing.py
+++ b/requre/postprocessing.py
@@ -1,7 +1,16 @@
+import os
 import logging
 from typing import Union, Any, Dict, Optional, List
 from .constants import KEY_MINIMAL_MATCH, METATADA_KEY
 from .cassette import DataMiner, DataStructure, DataTypes
+from glob import glob
+import tarfile
+import tempfile
+import shutil
+from subprocess import check_output, CalledProcessError
+import hashlib
+from _hashlib import HASH as Hash
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -112,3 +121,113 @@ class DictProcessing:
             else:
                 for v in internal_object.values():
                     self.simplify(internal_object=v, ignore_list=ignore_list)
+
+
+class tarFilesSimilarity:
+    def __init__(self, path, hash_function=None):
+        self.mapping_table = {}
+        self.path = path
+        for tar_file in self.list_files(path):
+            current_hash = self.untar_and_return_hash(tar_file, hash_function)
+            self.mapping_table[tar_file] = current_hash
+
+    @staticmethod
+    def md5_update_from_file(filename: Union[str, Path], hash: Hash) -> Hash:
+        # https://stackoverflow.com/questions/24937495/how-can-i-calculate-a-hash-for-a-filesystem-directory-using-python
+        assert Path(filename).is_file()
+        with open(str(filename), "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                hash.update(chunk)
+        return hash
+
+    @staticmethod
+    def md5_file(filename: Union[str, Path]) -> str:
+        return str(
+            tarFilesSimilarity.md5_update_from_file(filename, hashlib.md5()).hexdigest()
+        )
+
+    @staticmethod
+    def md5_update_from_dir(directory: Union[str, Path], hash: Hash) -> Hash:
+        assert Path(directory).is_dir()
+        for path in sorted(Path(directory).iterdir(), key=lambda p: str(p).lower()):
+            hash.update(path.name.encode())
+            if path.is_file():
+                hash = tarFilesSimilarity.md5_update_from_file(path, hash)
+            elif path.is_dir():
+                hash = tarFilesSimilarity.md5_update_from_dir(path, hash)
+        return hash
+
+    @staticmethod
+    def md5_dir(directory: Union[str, Path]) -> str:
+        return str(
+            tarFilesSimilarity.md5_update_from_dir(directory, hashlib.md5()).hexdigest()
+        )
+
+    @staticmethod
+    def list_files(path, pattern="*.tar.xz"):
+        return glob(f"{path}/**/{pattern}", recursive=True)
+
+    @staticmethod
+    def hash_fn(content):
+        if os.path.isdir(content):
+            try:
+                os.chdir(content)
+                return "git-sha", check_output(["git", "rev-parse", "HEAD"])
+            except (FileNotFoundError, CalledProcessError):
+                return "md5-dir", tarFilesSimilarity.md5_dir(content)
+        else:
+            return "md5-file", tarFilesSimilarity.md5_file(content)
+
+    @staticmethod
+    def untar_and_return_hash(tar_archive_path, hash_funciton):
+        hash_funciton = hash_funciton or tarFilesSimilarity.hash_fn
+        tempdir = tempfile.mkdtemp()
+        currentdir = os.getcwd()
+        try:
+            os.chdir(tempdir)
+            tar_file = tarfile.open(tar_archive_path)
+            tar_file.extractall()
+            files = os.listdir(".")
+            if len(files) != 1:
+                logger.debug("tar not packed by requre")
+                return None
+            content = files[0]
+            return hash_funciton(content)
+        finally:
+            os.chdir(currentdir)
+            shutil.rmtree(tempdir, ignore_errors=True)
+
+    def find_same(self):
+        item_dict = {}
+        for k, v in self.mapping_table.items():
+            if v not in item_dict:
+                item_dict[v] = [k]
+            else:
+                item_dict[v].append(k)
+        return item_dict
+
+    def symlink_same_files(self):
+        for k, v in self.find_same().items():
+            if k is None:
+                logger.debug(f"items not created by requre: {v}")
+            if len(v) == 1:
+                logger.debug(f"no duplication found: {v}")
+            else:
+                main_file = v[0]
+                relative_main = main_file.replace(self.path, "")
+                rest_files = v[1:]
+                for file in rest_files:
+                    if os.path.islink(file):
+                        logger.debug(
+                            f"{file} already symlinked to {os.path.realpath(file)}"
+                        )
+                        continue
+                    relative_file = file.replace(self.path, "")
+                    dir_deep = len(
+                        os.path.dirname(relative_file)
+                        .strip(os.path.sep)
+                        .split(os.path.sep)
+                    )
+                    main_relative_file = f"..{os.path.sep}" * dir_deep + relative_main
+                    os.remove(file)
+                    os.symlink(main_relative_file, file)

--- a/requre/requre_patch.py
+++ b/requre/requre_patch.py
@@ -11,7 +11,7 @@ import yaml
 import builtins
 
 from requre.import_system import upgrade_import_system, UpgradeImportSystem
-from requre.postprocessing import DictProcessing
+from requre.postprocessing import DictProcessing, tarFilesSimilarity
 from requre.storage import PersistentObjectStorage
 from requre.constants import (
     ENV_REPLACEMENT_FILE,
@@ -247,6 +247,27 @@ def purge(replaces, files, dry_run, simplify):
             click.echo(f"Writing content back to file: {one_file.name}")
             with open(one_file.name, mode="w") as outfile:
                 outfile.write(yaml.safe_dump(object_representation))
+
+
+@requre_base.command()
+@click.argument("base_dir", nargs=1, type=click.Path())
+@click.option(
+    "--dry-run", is_flag=True, default=False, help="Do not write changes back"
+)
+def create_symlinks(base_dir, dry_run):
+    click.echo(f"Processing base dir: {base_dir}")
+    tar_dict = tarFilesSimilarity(base_dir)
+    similar = tar_dict.find_same()
+    for k, v in similar.items():
+        if k is not None:
+            click.echo(f"hash: {k}")
+            for item in v:
+                click.echo(f"\t{item.replace(base_dir, '').strip(os.path.sep)}")
+    if dry_run:
+        click.echo("dry-run mode: just listing similar files")
+        return
+    click.echo("Created symlinks for listed files")
+    tar_dict.symlink_same_files()
 
 
 if __name__ == "__main__" or not (__file__ and __file__.endswith(FILE_NAME)):

--- a/requre/requre_patch.py
+++ b/requre/requre_patch.py
@@ -11,7 +11,7 @@ import yaml
 import builtins
 
 from requre.import_system import upgrade_import_system, UpgradeImportSystem
-from requre.postprocessing import DictProcessing, tarFilesSimilarity
+from requre.postprocessing import DictProcessing, TarFilesSimilarity
 from requre.storage import PersistentObjectStorage
 from requre.constants import (
     ENV_REPLACEMENT_FILE,
@@ -256,7 +256,7 @@ def purge(replaces, files, dry_run, simplify):
 )
 def create_symlinks(base_dir, dry_run):
     click.echo(f"Processing base dir: {base_dir}")
-    tar_dict = tarFilesSimilarity(base_dir)
+    tar_dict = TarFilesSimilarity(base_dir)
     similar = tar_dict.find_same()
     for k, v in similar.items():
         if k is not None:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -41,7 +41,9 @@ class FileStorage(Base):
         tar_data = PersistentObjectStorage().cassette.content["X"]["file"]["tar"][
             "StoreFiles"
         ]["storage_test.yaml"]["target_dir"][0]["output"]
-        with BytesIO(tar_data) as tar_byte:
+        with BytesIO(
+            StoreFiles.read_file_content(cassette=self.cassette, file_name=tar_data)
+        ) as tar_byte:
             with tarfile.open(mode="r:xz", fileobj=tar_byte) as tar_archive:
                 self.assertIn(filename, [x.name for x in tar_archive.getmembers()][-1])
 


### PR DESCRIPTION
avoid duplication of stored files in test_data 

tested also with packit
```
$ ls -alh tests_recording/test_data/
total 556K
drwxrwxr-x. 4 jscotka jscotka 4.0K Sep 30 10:33 .
drwxrwxr-x. 4 jscotka jscotka 4.0K Sep 22 13:25 ..
-rw-rw-r--. 1 jscotka jscotka  18K Sep 30 10:34 gitsha:6b27ffacda06289ca2d546e15b3c96845243005f
-rw-rw-r--. 1 jscotka jscotka 517K Sep 30 10:34 gitsha:d0b1b9b54302de3b96d3bf62f692a6211f45780f
drwxrwxr-x. 2 jscotka jscotka 4.0K Sep 30 10:33 test_api
drwxrwxr-x. 2 jscotka jscotka 4.0K Sep 30 10:36 test_status
```

there is one side effect, sometimes it may be too aggressive for your purposes.  because it do just checksum based on file contents or git hash, so that in case something change e.g. file attributes like owner or time, it will be ignored, or when you change file and does not commit change, for this purpose there is switch to change this behaviour to take each file operation as unique, based on timestamp