### PR TITLE
Do not run tests for zuul gating

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -9,9 +9,6 @@
     gate:
       jobs:
         - pre-commit
-        - requre-tests
-        - requre-reverse-dep-ogr-tests
-        - requre-reverse-dep-packit-tests
 
 - job:
     name: requre-tests


### PR DESCRIPTION
The gating pipeline requires passing test pipeline.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>