### PR TITLE
Workflow for uploading release to PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,29 @@
+# Upload a Python package when a release is created
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
+
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Build a source tarball and a binary wheel
+        # https://pypa-build.readthedocs.io
+        run: |
+          python -m pip install build
+          python -m build --sdist --wheel
+
+      - name: Publish 📦 to PyPI
+        # https://github.com/pypa/gh-action-pypi-publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true


### PR DESCRIPTION
This creates a workflow in [Actions](https://github.com/packit/requre/actions) which will be triggered once you create a new release.
It will automatically upload the distribution to PyPI.

All you need to do:

1. [create a new API token on PyPI](https://pypi.org/manage/account/token/) with "Project: requre" scope
2. [create a new secret in this repo](https://github.com/packit/requre/settings/secrets/actions/new) with
    - Name: PYPI_API_TOKEN
    - Value: the token from previous step

One question: I see there's only tarball uploaded to [requre@PyPI](https://pypi.org/project/requre/#files). Do you think it's ok to build&upload (that's what this workflow does) ALSO a [wheel](https://pythonwheels.com)?