### PR TITLE
Fix reverse-dep-packit-tests

### DIFF
--- a/files/tasks/packit-deps.yaml
+++ b/files/tasks/packit-deps.yaml
@@ -8,6 +8,6 @@
     repo: https://github.com/packit-service/packit.git
     dest: "{{ reverse_dir }}"
 - name: install packit dependencies via ansible playbooks
-  command: ansible-playbook -e "ansible_python_interpreter=/usr/bin/python3" -v -c local -i localhost, files/zuul-install-requirements-pip.yaml
+  command: ansible-playbook -e "ansible_python_interpreter=/usr/bin/python3" -v -c local -i localhost, files/install-requirements-pip.yaml
   args:
     chdir: "{{ reverse_dir }}"


### PR DESCRIPTION
The file has been renamed since
https://github.com/packit/packit/commit/970ec257fc4e8fcec0b901def1f6f3729b494712