### PR TITLE
packit.yaml: Remove bogus synced_files config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,7 +1,5 @@
 ---
 specfile_path: fedora/python-requre.spec
-synced_files:
-  - fedora/changelog
 # https://packit.dev/docs/configuration/#top-level-keys
 downstream_package_name: python-requre
 upstream_project_url: https://github.com/packit/requre


### PR DESCRIPTION
This was inherited from packit.yaml in ogr, which had it as a leftover
from an rpmautospec experiment.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>