### PR TITLE
Release 0.7.1

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,9 @@ upstream_project_url: https://github.com/packit/requre
 # we are setting this so we can use packit from requre's dist-git
 # packit can't know what's the upstream name when running from distgit
 upstream_package_name: requre
+# Use release description from GitHub when updating the
+# changelog in Fedora.
+copy_upstream_release_description: true
 actions:
   # we need this b/c `git archive` doesn't put all the metadata in the tarball:
   #   LookupError: setuptools-scm was unable to detect version for '/builddir/build/BUILD/requre-0.11.1'.

--- a/fedora/python-requre.spec
+++ b/fedora/python-requre.spec
@@ -1,7 +1,7 @@
 %global srcname requre
 
 Name:           python-%{srcname}
-Version:        0.7.0
+Version:        0.7.1
 Release:        1%{?dist}
 Summary:        Python library what allows re/store output of various objects for testing
 
@@ -57,6 +57,9 @@ rm -rf %{srcname}.egg-info
 %{python3_sitelib}/%{srcname}-%{version}-py%{python3_version}.egg-info
 
 %changelog
+* Fri Apr 30 2021 Hunor Csomortáni <csomh@redhat.com> - 0.7.1-1
+- New upstream release: 0.7.1
+
 * Fri Mar 12 2021 Jan Ščotka <jscotka@redhat.com> - 0.7.0-1
 - New version
 


### PR DESCRIPTION
Two things happening here:
- Configure Packit to use the release description from GitHub to update the changelog in Fedora. Release notes on GitHub will need to be "spec-file-safe".
- Updated the spec-file to prepare a new release.