### PR TITLE
Fix record decorator

### DIFF
--- a/tests/data/special_requre_module.py
+++ b/tests/data/special_requre_module.py
@@ -19,3 +19,7 @@ class dynamic:
 
 def random_number():
     return random.random()
+
+
+def another_random_number():
+    return random.random()

--- a/tests/test_data/test_online_replacing/RecordDecoratorForClassMultiple.test_random.yaml
+++ b/tests/test_data/test_online_replacing/RecordDecoratorForClassMultiple.test_random.yaml
@@ -1,0 +1,39 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+tests.data.special_requre_module:
+  another_random_number:
+    - metadata:
+        guess_type: Simple
+        latency: 6.67572021484375e-06
+        module_call_list:
+          - unittest.main
+          - teamcity.unittestpy
+          - unittest.runner
+          - unittest.suite
+          - unittest.case
+          - requre.record_and_replace
+          - test_online_replacing
+          - requre.objects
+          - requre.cassette
+          - tests.data.special_requre_module
+          - another_random_number
+      output: 0.15676319106079073
+  random_number:
+    - metadata:
+        guess_type: Simple
+        latency: 9.059906005859375e-06
+        module_call_list:
+          - unittest.main
+          - teamcity.unittestpy
+          - unittest.runner
+          - unittest.suite
+          - unittest.case
+          - requre.record_and_replace
+          - test_online_replacing
+          - requre.objects
+          - requre.cassette
+          - tests.data.special_requre_module
+          - random_number
+      output: 0.6749983968044089

--- a/tests/test_data/test_online_replacing/RecordDecoratorForMethodMultiple.test_random.yaml
+++ b/tests/test_data/test_online_replacing/RecordDecoratorForMethodMultiple.test_random.yaml
@@ -1,0 +1,39 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+tests.data.special_requre_module:
+  another_random_number:
+    - metadata:
+        guess_type: Simple
+        latency: 5.7220458984375e-06
+        module_call_list:
+          - unittest.main
+          - teamcity.unittestpy
+          - unittest.runner
+          - unittest.suite
+          - unittest.case
+          - requre.record_and_replace
+          - test_online_replacing
+          - requre.objects
+          - requre.cassette
+          - tests.data.special_requre_module
+          - another_random_number
+      output: 0.039985857086601295
+  random_number:
+    - metadata:
+        guess_type: Simple
+        latency: 7.3909759521484375e-06
+        module_call_list:
+          - unittest.main
+          - teamcity.unittestpy
+          - unittest.runner
+          - unittest.suite
+          - unittest.case
+          - requre.record_and_replace
+          - test_online_replacing
+          - requre.objects
+          - requre.cassette
+          - tests.data.special_requre_module
+          - random_number
+      output: 0.2809709312583647

--- a/tests/test_online_replacing.py
+++ b/tests/test_online_replacing.py
@@ -208,11 +208,31 @@ class RecordDecoratorForClass(unittest.TestCase):
         self.assertEqual(random_number, 0.819349292484907)
 
 
+@record(what="tests.data.special_requre_module.random_number")
+@record(what="tests.data.special_requre_module.another_random_number")
+class RecordDecoratorForClassMultiple(unittest.TestCase):
+    def test_random(self):
+        random_number = tests.data.special_requre_module.random_number()
+        another_random_number = tests.data.special_requre_module.another_random_number()
+        self.assertEqual(0.6749983968044089, random_number)
+        self.assertEqual(0.15676319106079073, another_random_number)
+
+
 class RecordDecoratorForMethod(unittest.TestCase):
     @record(what="tests.data.special_requre_module.random_number")
     def test_random(self):
         random_number = tests.data.special_requre_module.random_number()
         self.assertEqual(random_number, 0.17583106733657616)
+
+
+class RecordDecoratorForMethodMultiple(unittest.TestCase):
+    @record(what="tests.data.special_requre_module.random_number")
+    @record(what="tests.data.special_requre_module.another_random_number")
+    def test_random(self):
+        random_number = tests.data.special_requre_module.random_number()
+        another_random_number = tests.data.special_requre_module.another_random_number()
+        self.assertEqual(0.2809709312583647, random_number)
+        self.assertEqual(0.039985857086601295, another_random_number)
 
 
 @record(what="tests.data.special_requre_module.random_number")


### PR DESCRIPTION
Unify `record` decorator with `replace` one
   
* By now, @record is only a thin wrapper with reduced options to not confuse regular users.
* Users need to use @replace if they want more options.
* This change fixes applying multiple @record decorators.
    
