### PR TITLE
Fix key-word decorators

### DIFF
--- a/requre/helpers/git/helper.py
+++ b/requre/helpers/git/helper.py
@@ -16,6 +16,7 @@ from requre.record_and_replace import (
 
 @make_generic
 def record_git_module(
+    _func=None,
     cassette: Optional[Cassette] = None,
 ):
     decorators = [
@@ -34,7 +35,12 @@ def record_git_module(
         ("git.remote.Remote.fetch", FetchInfoStorageList.decorator_plain()),
         ("git.remote.Remote.pull", FetchInfoStorageList.decorator_plain()),
     ]
-    return replace_module_match_with_multiple_decorators(
+    record_git_decorator = replace_module_match_with_multiple_decorators(
         *decorators,
         cassette=cassette,
     )
+
+    if _func is not None:
+        return record_git_decorator(_func)
+    else:
+        return record_git_decorator

--- a/requre/helpers/requests_response.py
+++ b/requre/helpers/requests_response.py
@@ -214,6 +214,7 @@ class RequestResponseHandling(ObjectStorage):
 
 @make_generic
 def record_requests(
+    _func=None,
     response_headers_to_drop: Optional[List[str]] = None,
     cassette: Optional[Cassette] = None,
 ):
@@ -235,19 +236,20 @@ def record_requests(
     """
 
     response_headers_to_drop = response_headers_to_drop or []
-
-    def record_requests_decorator_cover(func):
-        return replace(
-            what="requests.sessions.Session.send",
+    replace_decorator = replace(
+        what="requests.sessions.Session.send",
+        cassette=cassette,
+        decorate=RequestResponseHandling.decorator(
+            item_list=[1],
+            response_headers_to_drop=response_headers_to_drop,
             cassette=cassette,
-            decorate=RequestResponseHandling.decorator(
-                item_list=[1],
-                response_headers_to_drop=response_headers_to_drop,
-                cassette=cassette,
-            ),
-        )(func)
+        ),
+    )
 
-    return record_requests_decorator_cover
+    if _func is not None:
+        return replace_decorator(_func)
+    else:
+        return replace_decorator
 
 
 @contextmanager

--- a/requre/helpers/tempfile.py
+++ b/requre/helpers/tempfile.py
@@ -142,6 +142,7 @@ class TempFile(ObjectStorage):
 
 @make_generic
 def record_tempfile_module(
+    _func=None,
     cassette: Optional[Cassette] = None,
 ):
     """Records tempfile.mkdtemp and tempfile.mktemp calls."""
@@ -149,7 +150,12 @@ def record_tempfile_module(
         ("tempfile.mkdtemp", MkDTemp.decorator_plain()),
         ("tempfile.mktemp", MkTemp.decorator_plain()),
     ]
-    return replace_module_match_with_multiple_decorators(
+    record_tempfile_decorator = replace_module_match_with_multiple_decorators(
         *decorators,
         cassette=cassette,
     )
+
+    if _func is not None:
+        return record_tempfile_decorator(_func)
+    else:
+        return record_tempfile_decorator

--- a/requre/record_and_replace.py
+++ b/requre/record_and_replace.py
@@ -300,6 +300,28 @@ def make_generic(_decorator=None):
         @my_decorator
         def method_e(self):
             print("Will be decorated.")
+
+
+    Warning:
+        If you want to use make_generic with decorator accepting key-word arguments,
+        to be able to use the final decorator without arguments or without parenthesis,
+        use the following trick to correctly apply all decorators:
+
+        @make_generic
+        def add_something(_func=None, add=1):
+            def decorator_to_return(fce):
+                def fce_to_return():
+                    return fce() + add
+
+                return fce_to_return
+
+            if _func is None:
+                # @add_something()
+                return decorator_to_return
+            else:
+                # @add_something
+                return decorator_to_return(_func)
+
     """
 
     def make_generic_decorator_cover(decorator):

--- a/tests/test_make_generic.py
+++ b/tests/test_make_generic.py
@@ -183,3 +183,129 @@ class ApplyCommonCase(unittest.TestCase):
 
         assert SimpleUse().simple_use() == 1
         assert SimpleUse().test_simple_use() == 0
+
+    def test_double_use_on_decorator(self):
+        @make_generic
+        @make_generic
+        def add_one(fce):
+            def fce_to_return():
+                return fce() + 1
+
+            return fce_to_return
+
+        @add_one
+        def simple_use():
+            return 0
+
+        assert simple_use() == 1
+
+    def test_chain_of_decorators(self):
+        @make_generic
+        def plus_one(fce):
+            def fce_to_return():
+                return fce() + 1
+
+            return fce_to_return
+
+        @make_generic
+        def add_one(fce):
+            return plus_one(fce)
+
+        @add_one
+        def simple_use():
+            return 0
+
+        assert simple_use() == 1
+
+    def test_parenthesis_double_use_with_args(self):
+        @make_generic
+        @make_generic
+        def add_something(add):
+            def decorator_to_return(fce):
+                def fce_to_return():
+                    return fce() + add
+
+                return fce_to_return
+
+            return decorator_to_return
+
+        @add_something(1)
+        def parenthesis_use_with_args():
+            return 0
+
+        assert parenthesis_use_with_args() == 1
+
+    def test_use_with_args_chain_decorators(self):
+        @make_generic
+        def add_something(add):
+            def decorator_to_return(fce):
+                def fce_to_return():
+                    return fce() + add
+
+                return fce_to_return
+
+            return decorator_to_return
+
+        @make_generic
+        def add_one(fce):
+            return add_something(1)(fce)
+
+        @add_one
+        def parenthesis_use_with_args():
+            return 0
+
+        assert parenthesis_use_with_args() == 1
+
+    def test_parenthesis_use_with_args_not_set(self):
+        """
+        When using with optional arguments,
+        you need to use `if _func is None:....` trick in your decorator.
+        """
+
+        @make_generic
+        def add_something(_func=None, add=1):
+            def decorator_to_return(fce):
+                def fce_to_return():
+                    return fce() + add
+
+                return fce_to_return
+
+            if _func is None:
+                # @add_something()
+                return decorator_to_return
+            else:
+                # @add_something
+                return decorator_to_return(_func)
+
+        @add_something()
+        def parenthesis_use_with_args():
+            return 0
+
+        assert parenthesis_use_with_args() == 1
+
+    def test_simple_use_with_args_not_set(self):
+        """
+        When using with optional arguments,
+        you need to use `if _func is None:....` trick in your decorator.
+        """
+
+        @make_generic
+        def add_something(_func=None, add=1):
+            def decorator_to_return(fce):
+                def fce_to_return():
+                    return fce() + add
+
+                return fce_to_return
+
+            if _func is None:
+                # @add_something()
+                return decorator_to_return
+            else:
+                # @add_something
+                return decorator_to_return(_func)
+
+        @add_something
+        def parenthesis_use_with_args():
+            return 0
+
+        assert parenthesis_use_with_args() == 1


### PR DESCRIPTION
Fix key-word-only decorators that use `@make_generic`.
    
Such decorator needs to handle situation with and without parenthesis on its own with the following trick:

```python    
            @make_generic
            def add_something(_func=None, add=1):
                def decorator_to_return(fce):
                    def fce_to_return():
                        return fce() + add
    
                    return fce_to_return
    
                if _func is None:
                    # @add_something()
                    return decorator_to_return
                else:
                    # @add_something
                    return decorator_to_return(_func)
 ```

Otherwise, we can't differentiate decorator without arguments and with key-word arguments that are not set.
