### PR TITLE
Move Copr builds to packit-dev and packit-releases

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,6 +34,7 @@ jobs:
     trigger: commit
     metadata:
       branch: main
+      project: packit-dev
       targets:
         - fedora-all
         - epel-8
@@ -42,6 +43,7 @@ jobs:
   - job: copr_build
     trigger: release
     metadata:
+      project: packit-releases
       targets:
         - fedora-all
         - epel-8

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ $ pip3 install --user requre
 
 You can also install `requre` from `main` branch, if you are brave enough:
 
-You can use our [`packit/packit-requre-master` Copr repository](https://copr.fedorainfracloud.org/coprs/packit/packit-requre-master/):
+You can use our [`packit/packit-dev` Copr repository](https://copr.fedorainfracloud.org/coprs/packit/packit-dev/):
 
 ```
-$ dnf copr enable packit/packit-requre-master
+$ dnf copr enable packit/packit-dev
 $ dnf install python3-requre
 ```
 


### PR DESCRIPTION
Move Copr builds to packit-dev and packit-releases to be consistent with
other Packit projects that are built in Copr.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] Check if `requre` is not installed from Copr in any of the tests
- [x] Check downloads of requre from the soon-to-be deprecated Copr projects

Related to packit/packit.dev#339

Merge before packit/packit.dev#339

---

<!-- release notes for changelog/blog follow -->

note: _already included in the other PR_