### PR TITLE
Unify the configuration of prod and stage Packit instance

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,4 +1,7 @@
 ---
+# We want to use both instances for all upstream jobs including the `propose-downstream` one.
+# For downstream, we need to pick just one instance (`stg` in our case)
+# and redefine it for the `koji_build` and `bodhi_update` jobs.
 packit_instances: ["prod", "stg"]
 specfile_path: fedora/python-requre.spec
 # https://packit.dev/docs/configuration/#top-level-keys
@@ -30,7 +33,6 @@ jobs:
     trigger: commit
   - job: propose_downstream
     trigger: release
-    packit_instances: ["prod", "stg"]
     metadata:
       dist_git_branches: fedora-all
   - job: copr_build


### PR DESCRIPTION
We want to use both instances for all upstream jobs including the `propose-downstream` one.
For downstream, we need to pick just one instance (`stg` in our case)
and redefine it for the `koji_build` and `bodhi_update` jobs.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>