### PR TITLE
Enable EPEL 9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,6 +40,7 @@ jobs:
     targets:
       - fedora-all
       - epel-8
+      - epel-9
   - job: copr_build
     trigger: commit
     branch: main
@@ -47,6 +48,7 @@ jobs:
     targets:
       - fedora-all
       - epel-8
+      - epel-9
     list_on_homepage: True
     preserve_project: True
   - job: copr_build
@@ -55,6 +57,7 @@ jobs:
     targets:
       - fedora-all
       - epel-8
+      - epel-9
     list_on_homepage: True
     preserve_project: True
 
@@ -65,6 +68,7 @@ jobs:
     dist_git_branches:
       - fedora-all
       - epel-8
+      - epel-9
   - job: bodhi_update
     trigger: commit
     packit_instances: ["stg"]
@@ -72,3 +76,4 @@ jobs:
       - fedora-latest # branched version, rawhide updates are created automatically
       - fedora-stable
       - epel-8
+      - epel-9


### PR DESCRIPTION
A note: there is downstream automation configured for EPEL 8, so I added EPEL 9 as well, but requre doesn't have epel* branches in Fedora dist-git.