### PR TITLE
GitHub token

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: |
+      - name: Create GitHub release
+        run: |
           VERSION=$(grep -oP '^# \K[0-9.]*' CHANGELOG.md | head -n 1)
           # Take the lines between the first two headers from CHANGELOG.md,
           # and use it as a description for the new release.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,13 +21,10 @@ jobs:
         with:
           version: ${{ inputs.version }}
           specfiles: fedora/python-requre.spec
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           labels: release
-          token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
           commit-message: Release ${{ inputs.version }}
           title: Release ${{ inputs.version }}
           body: Update the changelog and the specfile for release ${{ inputs.version }}.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
 
       - name: Build a source tarball and a binary wheel


### PR DESCRIPTION
Both, the [packit/prepare-release](https://github.com/peter-evans/create-pull-request#action-inputs) & [peter-evans/create-pull-request](https://github.com/packit/prepare-release#packitprepare-release) default to using (autogenerated) [secrets.GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) if no token is provided.

That token should be enough because the steps are repo-scoped and [don't trigger any other workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) since the PR which triggers the 'Create GitHub release' is manually merged by a user.

Seems to work OK - jpopelka/packit#1