### PR TITLE
Publishing to PyPI with a Trusted Publisher

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
 
       - name: Build a source tarball and a binary wheel
         # https://pypa-build.readthedocs.io

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-n-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for trusted publishing
 
     steps:
       - uses: actions/checkout@v3
@@ -25,5 +27,4 @@ jobs:
         # https://github.com/pypa/gh-action-pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
@jscotka This will allow us to stop using your PyPI token for publishing requre.

I need you to [Add a new publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) in [PyPI](https://pypi.org/manage/project/requre/settings/publishing/)
```
Owner: packit
Repository name: requre
Workflow name: pypi-publish.yml
(leave "Environment name" empty)
```
(or add me as a Maintainer so that I can do that)