### PR TITLE
Fix tracebacks with enabled coverage

### DIFF
--- a/requre/record_and_replace.py
+++ b/requre/record_and_replace.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import sys
+import types
 from contextlib import contextmanager
 from typing import Any, Callable, List, Optional, Tuple, Union
 
@@ -193,6 +194,10 @@ def _parse_and_replace_sys_modules(
     module_list: List[ModuleRecord] = []
     # go over all modules, and try to find match
     for module in sys.modules.copy().values():
+        if not isinstance(module, types.ModuleType):
+            # ignore non-modules (for example coverage abuses sys.modules
+            # to store its DebugOutputFile object)
+            continue
         module_list += _apply_module_replacement(
             what=what,
             module=module,


### PR DESCRIPTION
coverage [abuses](https://github.com/nedbat/coveragepy/blob/48126d4b5f78fea6ce58c211805231f57a7894a2/coverage/debug.py#L365-L368) `sys.modules` to store its `DebugOutputFile` object, so it is necessary to filter out non-module objects.