### PR TITLE
Change order of tests to prevent a failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,10 @@ def remove_storage_file_after(request):
     # PersistentObjectStorage().cassette.dump()
     if storage_file.is_file():
         storage_file.unlink()
+
+
+def pytest_collection_modifyitems(items):
+    # make sure Duplicated::test test is executed last
+    items[:] = sorted(
+        items, key=lambda i: i.cls is not None and i.cls.__name__ == "Duplicated"
+    )


### PR DESCRIPTION
Make sure `Duplicated::test` is executed after `StoreFunctionOutput::test_a` to prevent it from using its test data and failing.

Ordering of tests changed with newer versions of pytest, making this issue appear. I don't understand requre enough to be able to say what causes the test to use wrong test data (I assume some sort of a clean-up is missing somewhere) and fix the actual issue.