### PR TITLE
Provide __version__ of the package

### DIFF
--- a/requre/__init__.py
+++ b/requre/__init__.py
@@ -1,6 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import contextlib
+from importlib.metadata import PackageNotFoundError, distribution
+
 from requre.base_testclass import RequreTestCase
 from requre.record_and_replace import record, replace
 from requre.cassette import Cassette
@@ -8,6 +11,9 @@ from requre.simple_object import Simple, Tuple
 from requre.guess_object import Guess
 from requre.helpers.files import StoreFiles
 from requre.import_system import UpgradeImportSystem
+
+with contextlib.suppress(PackageNotFoundError):
+    __version__ = distribution(__name__).version
 
 __all__ = [
     record.__name__,


### PR DESCRIPTION
So it can be easily checked when installed on the system.