### PR TITLE
fix(patch): adjust to not trip false positives

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,8 +16,9 @@
     --replaces "github.Requester%requests.sessions%send:Content-Security-Policy:str:default-src 'none'"
     --replaces "requests.sessions%_content:expires_at:str:2019-11-01T14:35:53Z"
     --replaces "requests.sessions%send:elapsed:float:0.2"
-    --replaces "requests.sessions%_content:token:str:v1.1cd89d399b8c70f8b88e22cbdaa72abbe5e390db"
+    --replaces "requests.sessions%_content:token:str:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     --replaces ":set-cookie:str:a 'b';"
+    --replaces ":Set-Cookie:str:a='b';"
     --replaces "copr.v3.helpers:login:str:somelogin"
     --replaces "copr.v3.helpers:token:str:sometoken"
   language: python

--- a/plans/ogr-integration.fmf
+++ b/plans/ogr-integration.fmf
@@ -22,3 +22,7 @@ adjust:
   - when: "distro == rhel-8 or distro == centos-8 or distro == centos-stream-8"
     because: "ogr doesn't support EL 8"
     enabled: false
+
+  - when: "distro == centos-stream-9 or distro == fedora-40"
+    because: "packaged version of python-pyforgejo is not sufficient"
+    enabled: false


### PR DESCRIPTION
• ‹token› is being used by GitHub, even though we replace it for a dummy
  value that has no meaning, it still looks like a valid token, so it
  triggers the “Data leak protection”
• ‹Set-Cookie› is used by Pagure, it appears that it contains a cookie
  for authenticating the session; same as before, not valid anymore, but
  for the safety reasons
  · also it looks like the replacement is case-sensitive as there is
    already one replacement defined for ‹set-cookie›